### PR TITLE
Update base image to maintained centos s2i base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/base-centos7
+FROM centos/s2i-base-centos7
 
 MAINTAINER Tobias Brunner <tobias.brunner@vshn.ch>
 


### PR DESCRIPTION
the openshift/base-centos7 image is unmaintained. This PR updates the base image of the gradle s2i image.